### PR TITLE
Add cluster server config and admin UI

### DIFF
--- a/server/firestore.rules
+++ b/server/firestore.rules
@@ -103,9 +103,9 @@ service cloud.firestore {
       allow read, write: if isAdmin();
     }
 
-    // App configuration - authenticated users can read, only admins can write
+    // App configuration - public read (contains non-sensitive server config), only admins can write
     match /app-config/{document} {
-      allow read: if isAuthenticated();
+      allow read: if true;
       allow write: if isAdmin();
     }
 

--- a/src/services/appConfigService.js
+++ b/src/services/appConfigService.js
@@ -4,8 +4,12 @@ import { doc, getDoc, getDocFromServer, setDoc, serverTimestamp } from 'firebase
 const CONFIG_DOC = doc(db, 'app-config', 'backend')
 
 let cachedHoldDetectionServerUrl = null
-let cachedAtMs = 0
-let inFlightPromise = null
+let cachedHoldDetectionAtMs = 0
+let inFlightHoldDetectionPromise = null
+
+let cachedClusterServerUrl = null
+let cachedClusterAtMs = 0
+let inFlightClusterPromise = null
 
 const CACHE_TTL_MS = 5 * 60 * 1000
 
@@ -17,15 +21,15 @@ export async function getBackendAppConfig({ forceRefresh = false } = {}) {
 export async function getHoldDetectionServerUrl({ forceRefresh = false } = {}) {
   const now = Date.now()
 
-  if (!forceRefresh && cachedHoldDetectionServerUrl && now - cachedAtMs < CACHE_TTL_MS) {
+  if (!forceRefresh && cachedHoldDetectionServerUrl && now - cachedHoldDetectionAtMs < CACHE_TTL_MS) {
     return cachedHoldDetectionServerUrl
   }
 
-  if (!forceRefresh && inFlightPromise) {
-    return inFlightPromise
+  if (!forceRefresh && inFlightHoldDetectionPromise) {
+    return inFlightHoldDetectionPromise
   }
 
-  inFlightPromise = (async () => {
+  inFlightHoldDetectionPromise = (async () => {
     const data = await getBackendAppConfig({ forceRefresh: true })
     const url = data?.holdDetection?.serverUrl
 
@@ -36,14 +40,14 @@ export async function getHoldDetectionServerUrl({ forceRefresh = false } = {}) {
     }
 
     cachedHoldDetectionServerUrl = url
-    cachedAtMs = Date.now()
+    cachedHoldDetectionAtMs = Date.now()
     return url
   })()
 
   try {
-    return await inFlightPromise
+    return await inFlightHoldDetectionPromise
   } finally {
-    inFlightPromise = null
+    inFlightHoldDetectionPromise = null
   }
 }
 
@@ -66,12 +70,73 @@ export async function setHoldDetectionServerUrl(serverUrl) {
     { merge: true }
   )
 
-  // Ensure the write reached the server (avoids "saved but not committed yet" confusion)
   await getDocFromServer(CONFIG_DOC)
 
   cachedHoldDetectionServerUrl = normalizedUrl
-  cachedAtMs = Date.now()
-  inFlightPromise = null
+  cachedHoldDetectionAtMs = Date.now()
+  inFlightHoldDetectionPromise = null
+
+  return normalizedUrl
+}
+
+/**
+ * Get the cluster server URL.
+ * Falls back to the hold detection server URL if cluster.serverUrl is not set.
+ */
+export async function getClusterServerUrl({ forceRefresh = false } = {}) {
+  const now = Date.now()
+
+  if (!forceRefresh && cachedClusterServerUrl && now - cachedClusterAtMs < CACHE_TTL_MS) {
+    return cachedClusterServerUrl
+  }
+
+  if (!forceRefresh && inFlightClusterPromise) {
+    return inFlightClusterPromise
+  }
+
+  inFlightClusterPromise = (async () => {
+    const data = await getBackendAppConfig({ forceRefresh: true })
+    // Fall back to holdDetection.serverUrl if cluster.serverUrl is not configured
+    const url = data?.cluster?.serverUrl || data?.holdDetection?.serverUrl
+
+    if (!url || typeof url !== 'string') {
+      throw new Error(
+        "Cluster server URL not configured. Set 'app-config/backend.cluster.serverUrl' (use /admin/healthcheck)."
+      )
+    }
+
+    cachedClusterServerUrl = url
+    cachedClusterAtMs = Date.now()
+    return url
+  })()
+
+  try {
+    return await inFlightClusterPromise
+  } finally {
+    inFlightClusterPromise = null
+  }
+}
+
+export async function setClusterServerUrl(serverUrl) {
+  const normalizedUrl = typeof serverUrl === 'string' ? serverUrl.trim().replace(/\/+$/, '') : ''
+
+  await setDoc(
+    CONFIG_DOC,
+    {
+      cluster: {
+        serverUrl: normalizedUrl || null,
+        updatedAt: serverTimestamp(),
+      },
+      updatedAt: serverTimestamp(),
+    },
+    { merge: true }
+  )
+
+  await getDocFromServer(CONFIG_DOC)
+
+  cachedClusterServerUrl = normalizedUrl
+  cachedClusterAtMs = Date.now()
+  inFlightClusterPromise = null
 
   return normalizedUrl
 }

--- a/src/views/AdminHealthcheckView.vue
+++ b/src/views/AdminHealthcheckView.vue
@@ -147,6 +147,55 @@
           </div>
         </div>
 
+        <!-- Cluster Service -->
+        <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
+          <div class="px-6 py-4 border-b border-gray-200 bg-gray-50">
+            <h2 class="text-lg font-semibold text-gray-900">Cluster Service</h2>
+            <p class="text-xs text-gray-500 mt-1">Used for draft problem clustering and magic wand. Falls back to Hold Detection URL if not set.</p>
+          </div>
+          <div class="px-6 py-4 space-y-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-2">Server URL</label>
+              <div class="flex items-center gap-2">
+                <div class="flex-1 px-3 py-2 bg-gray-50 border border-gray-300 rounded-md text-sm font-mono text-gray-900">
+                  {{ firestoreConfig?.cluster?.serverUrl || '(not set — falls back to Hold Detection URL)' }}
+                </div>
+                <a
+                  v-if="firestoreConfig?.cluster?.serverUrl"
+                  :href="firestoreConfig.cluster.serverUrl"
+                  target="_blank"
+                  class="h-9 px-4 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors flex items-center gap-2"
+                >
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                  </svg>
+                  Open
+                </a>
+              </div>
+
+              <div class="flex items-center gap-2 mt-3">
+                <input
+                  v-model="clusterUrlDraft"
+                  placeholder="https://… (leave empty to use Hold Detection URL)"
+                  class="flex-1 h-9 px-3 border border-gray-300 rounded-md text-sm font-mono text-gray-900"
+                />
+                <button
+                  @click="saveClusterUrl"
+                  :disabled="savingClusterUrl"
+                  class="h-9 px-4 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <span v-if="!savingClusterUrl">Save</span>
+                  <span v-else>Saving...</span>
+                </button>
+              </div>
+
+              <div v-if="clusterUrlSaveResult" class="mt-2 px-3 py-2 rounded-md text-sm font-medium" :class="clusterUrlSaveResult.success ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'">
+                {{ clusterUrlSaveResult.message }}
+              </div>
+            </div>
+          </div>
+        </div>
+
         <!-- System Info -->
         <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
           <div class="px-6 py-4 border-b border-gray-200 bg-gray-50">
@@ -174,7 +223,7 @@
 import { ref, onMounted } from 'vue';
 import { functions } from '@/services/firebase';
 import { httpsCallable } from 'firebase/functions';
-import { getBackendAppConfig, setHoldDetectionServerUrl } from '@/services/appConfigService'
+import { getBackendAppConfig, setHoldDetectionServerUrl, setClusterServerUrl } from '@/services/appConfigService'
 
 const loading = ref(true);
 const error = ref(null);
@@ -188,6 +237,10 @@ const matchTestResult = ref(null);
 const serverUrlDraft = ref('')
 const savingServerUrl = ref(false)
 const serverUrlSaveResult = ref(null)
+
+const clusterUrlDraft = ref('')
+const savingClusterUrl = ref(false)
+const clusterUrlSaveResult = ref(null)
 
 // 100x100 test images with actual features (checkerboard pattern)
 // These have corners and edges that feature detectors can find
@@ -207,6 +260,7 @@ const loadConfig = async ({ silent = false } = {}) => {
     config.value = backendConfig
     firestoreConfig.value = appConfig
     serverUrlDraft.value = firestoreConfig.value?.holdDetection?.serverUrl || ''
+    clusterUrlDraft.value = firestoreConfig.value?.cluster?.serverUrl || ''
   } catch (err) {
     console.error('Error loading backend config:', err);
     error.value = err.message || 'Failed to load configuration';
@@ -248,6 +302,40 @@ const saveServerUrl = async () => {
     }
   } finally {
     savingServerUrl.value = false
+  }
+}
+
+const saveClusterUrl = async () => {
+  savingClusterUrl.value = true
+  clusterUrlSaveResult.value = null
+
+  try {
+    const nextUrl = clusterUrlDraft.value?.trim()
+    // Allow empty string to clear the cluster URL (will fall back to hold detection URL)
+    if (nextUrl && !/^https?:\/\//i.test(nextUrl)) {
+      throw new Error('URL must start with http:// or https://')
+    }
+
+    const saved = await setClusterServerUrl(nextUrl || '')
+    clusterUrlDraft.value = saved
+    clusterUrlSaveResult.value = { success: true, message: '✅ Saved' }
+
+    firestoreConfig.value = {
+      ...(firestoreConfig.value || {}),
+      cluster: {
+        ...(firestoreConfig.value?.cluster || {}),
+        serverUrl: saved,
+      }
+    }
+
+    await loadConfig({ silent: true })
+  } catch (err) {
+    clusterUrlSaveResult.value = {
+      success: false,
+      message: `❌ Save failed: ${err.message || err}`
+    }
+  } finally {
+    savingClusterUrl.value = false
   }
 }
 

--- a/src/views/HoldDetectionServerView.vue
+++ b/src/views/HoldDetectionServerView.vue
@@ -1193,7 +1193,7 @@ import HoldMatchVisualizer from '@/components/HoldMatchVisualizer.vue';
 import { ensureHoldHasSvgMarkup } from '@/utils/svgUtils.js';
 import { hexToColorName, precomputeHoldHues } from '@/utils/colorUtils.js';
 import { performMagicWandSelection } from '@/utils/magicWandUtils.js';
-import { getHoldDetectionServerUrl } from '@/services/appConfigService';
+import { getHoldDetectionServerUrl, getClusterServerUrl } from '@/services/appConfigService';
 import { mapMatchesToHolds, computeHoldToHoldMapping, computeMatchToDetectionScale } from '@/utils/holdMatcher';
 // Note: Not using getResizedImageUrl - we load original images to match detection coordinates
 
@@ -1344,7 +1344,7 @@ const callFeMagicWand = async (hold) => {
 const callServerMagicWand = async (holdId) => {
   const imageId = route.query.imageId;
   if (!imageId || !holdId) return null;
-  const baseUrl = await getHoldDetectionServerUrl();
+  const baseUrl = await getClusterServerUrl();
   const res = await fetch(`${baseUrl}/cluster/magic-wand`, {
     method: 'POST',
     headers: {
@@ -1480,7 +1480,7 @@ const fetchDrafts = async () => {
   selectedDraftClusterId.value = null;
 
   try {
-    const baseUrl = await getHoldDetectionServerUrl();
+    const baseUrl = await getClusterServerUrl();
     const res = await fetch(`${baseUrl}/cluster`, {
       method: 'POST',
       headers: {


### PR DESCRIPTION
Expose a new cluster.serverUrl setting with client helpers and admin controls. Changes include:

- Firestore rules: make app-config documents readable publicly (contains non-sensitive server config), only admins can write.
- services/appConfigService.js: introduce getClusterServerUrl and setClusterServerUrl with their own cache + in-flight promise; fall back to holdDetection.serverUrl if cluster.serverUrl is not set. Rename/refactor hold-detection cache/in-flight variables to avoid collisions.
- views/AdminHealthcheckView.vue: add UI to view, open, edit and save the Cluster Service URL, including validation, save feedback and local state updates.
- views/HoldDetectionServerView.vue: switch cluster-related requests to use getClusterServerUrl instead of getHoldDetectionServerUrl so cluster endpoints use the new config.

This enables configuring a separate cluster service (used for clustering and magic-wand) while preserving the old hold-detection URL as a fallback.