### PR TITLE
Add pickOrder/batchUploadedAt for image batches

### DIFF
--- a/server/migrations/v0.0.23__backfill_pickOrder_batchUploadedAt_to_locationImages.ts
+++ b/server/migrations/v0.0.23__backfill_pickOrder_batchUploadedAt_to_locationImages.ts
@@ -1,0 +1,59 @@
+/**
+ * Migration: Backfill pickOrder and batchUploadedAt on existing locationImages documents.
+ *
+ * These fields were added to preserve file-picker ordering when multiple photos are
+ * uploaded in a single batch. Existing images have neither field.
+ *
+ * For legacy images we have no way to know the original picker order, so we assign:
+ *   - pickOrder: 0  (single-item batch, no relative ordering ambiguity)
+ *   - batchUploadedAt: uploadedAt.toMillis()  (treat each legacy image as its own batch)
+ *
+ * This keeps the sort deterministic (newest first) and indistinguishable from the
+ * old uploadedAt-desc behaviour for images that were uploaded one at a time.
+ */
+
+export async function migrate(firestore: any): Promise<void> {
+  console.log('🚀 Backfilling pickOrder + batchUploadedAt on locationImages...\n');
+
+  const db = firestore.firestore;
+
+  const snapshot = await db.collection('locationImages').get();
+  console.log(`📸 Found ${snapshot.size} locationImages documents`);
+
+  let batch = db.batch();
+  let batchCount = 0;
+  let totalFixed = 0;
+  const MAX_BATCH_SIZE = 500;
+
+  const commitBatch = async () => {
+    if (batchCount === 0) return;
+    await batch.commit();
+    console.log(`  ✅ Committed batch of ${batchCount}`);
+    batch = db.batch();
+    batchCount = 0;
+  };
+
+  for (const doc of snapshot.docs) {
+    const data = doc.data();
+    if (data.pickOrder !== undefined && data.batchUploadedAt !== undefined) continue;
+
+    const uploadedAtMs: number =
+      data.uploadedAt && typeof data.uploadedAt.toMillis === 'function'
+        ? data.uploadedAt.toMillis()
+        : Date.now();
+
+    batch.update(doc.ref, {
+      pickOrder: 0,
+      batchUploadedAt: uploadedAtMs,
+    });
+    batchCount++;
+    totalFixed++;
+
+    if (batchCount >= MAX_BATCH_SIZE) {
+      await commitBatch();
+    }
+  }
+
+  await commitBatch();
+  console.log(`\n✅ Done. Backfilled ${totalFixed} documents.`);
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -196,13 +196,22 @@ interface LocationImage {
   uploadedAt?: Date;
   routesettings: string[]; // Array of ISO timestamps (YYYY-MM-DDTHH:mm:ss) - which routesettings use this image
   replacesImageId?: string; // Set at upload time when this image replaces a wall photo from a previous routesetting
+  pickOrder: number; // 0-based index of this file within its upload batch (preserves file picker order)
+  batchUploadedAt: number; // epoch ms, set once client-side per batch so all files in batch share same value
 }
+
+const byBatchOrder = (a: LocationImage, b: LocationImage) =>
+  b.batchUploadedAt !== a.batchUploadedAt
+    ? b.batchUploadedAt - a.batchUploadedAt
+    : a.pickOrder - b.pickOrder;
 
 // Input type for addLocationImage (omit uploadedAt which is added server-side)
 // When creating, client provides single routesetting, server converts to array
 type AddLocationImageRequest = Omit<LocationImage, 'uploadedAt' | 'routesettings'> & {
   routesetting: string; // Single routesetting when creating (converted to array server-side)
   replacesImageId?: string;
+  pickOrder: number;
+  batchUploadedAt: number;
 };
 
 // Toggle location like (add/remove)
@@ -666,10 +675,13 @@ export const deleteLocation = onCall({region: REGION}, async (request) => {
 export const addLocationImage = onCall({region: REGION}, async (request) => {
   try {
     // Input: imageId is the client-generated ID that becomes the Firestore doc ID
-    const { imageId, locationId, fileName, downloadUrl, routesetting, replacesImageId } = request.data as AddLocationImageRequest;
+    const { imageId, locationId, fileName, downloadUrl, routesetting, replacesImageId, pickOrder, batchUploadedAt } = request.data as AddLocationImageRequest;
 
     if (!imageId || !locationId || !fileName || !downloadUrl || !routesetting) {
       throw new Error("imageId, locationId, fileName, downloadUrl, and routesetting are required");
+    }
+    if (pickOrder === undefined || batchUploadedAt === undefined) {
+      throw new Error("pickOrder and batchUploadedAt are required");
     }
 
     // Data to store
@@ -679,6 +691,8 @@ export const addLocationImage = onCall({region: REGION}, async (request) => {
       fileName,
       downloadUrl,
       routesettings: [routesetting], // Image belongs to this routesetting
+      pickOrder,
+      batchUploadedAt,
       ...(replacesImageId ? { replacesImageId } : {}),
     };
 
@@ -743,12 +757,7 @@ export const getLocationImages = onCall({region: REGION}, async (request) => {
         }
       });
       
-      // Sort by uploadedAt descending
-      images.sort((a, b) => {
-        const aTime = a.uploadedAt instanceof Date ? a.uploadedAt.getTime() : 0;
-        const bTime = b.uploadedAt instanceof Date ? b.uploadedAt.getTime() : 0;
-        return bTime - aTime;
-      });
+      images.sort(byBatchOrder);
 
       logger.info(`Returning ${images.length} filtered images`);
       return images;
@@ -759,7 +768,6 @@ export const getLocationImages = onCall({region: REGION}, async (request) => {
     const snapshot = await db
       .collection("locationImages")
       .where("locationId", "==", locationId)
-      .orderBy("uploadedAt", "desc")
       .get();
 
     const images: LocationImage[] = [];
@@ -769,6 +777,8 @@ export const getLocationImages = onCall({region: REGION}, async (request) => {
         ...doc.data(),
       } as LocationImage);
     });
+
+    images.sort(byBatchOrder);
 
     return images;
   } catch (error) {

--- a/src/components/ImageUpload.vue
+++ b/src/components/ImageUpload.vue
@@ -271,10 +271,11 @@ const createUploadItem = (file) => {
 };
 
 const addFilesToQueue = (files) => {
+  const batchUploadedAt = Date.now();
   const validFiles = [];
   let hasError = false;
 
-  Array.from(files).forEach((file) => {
+  Array.from(files).forEach((file, fileIndex) => {
     const error = validateFile(file);
     console.log('after validateFile', error);
     if (error) {
@@ -289,7 +290,10 @@ const addFilesToQueue = (files) => {
     );
 
     if (!exists) {
-      validFiles.push(createUploadItem(file));
+      const item = createUploadItem(file);
+      item.pickOrder = fileIndex;
+      item.batchUploadedAt = batchUploadedAt;
+      validFiles.push(item);
     }
   });
 
@@ -425,6 +429,8 @@ const startUploads = async () => {
           locationId: props.locationId,
           routesetting: props.routesetting, // Routesetting timestamp for version control
           replacesImageId: props.replacesImageId,
+          pickOrder: item.pickOrder,
+          batchUploadedAt: item.batchUploadedAt,
         });
 
         results.push({ success: true, item });
@@ -448,6 +454,8 @@ const startUploads = async () => {
           locationId: props.locationId,
           routesetting: props.routesetting,
           replacesImageId: props.replacesImageId,
+          pickOrder: item.pickOrder,
+          batchUploadedAt: item.batchUploadedAt,
         });
 
         return { success: true, item };

--- a/src/composables/useSortedImages.js
+++ b/src/composables/useSortedImages.js
@@ -1,20 +1,14 @@
 import { computed } from 'vue';
 
-/**
- * Composable to sort images by floorplan sections
- * 
- * Images are ordered by:
- * 1. First, images assigned to sections (in section order)
- * 2. Then, unassigned images
- * 
- * @param {Ref<Array>} images - Array of image objects with imageId
- * @param {Ref<Object>} floorplan - Floorplan object with sections array
- * @returns {ComputedRef<Array>} Sorted images
- */
+const byBatchOrder = (a, b) =>
+  b.batchUploadedAt !== a.batchUploadedAt
+    ? b.batchUploadedAt - a.batchUploadedAt
+    : a.pickOrder - b.pickOrder;
+
 export function useSortedImages(images, floorplan) {
   return computed(() => {
     if (!floorplan.value?.sections || floorplan.value.sections.length === 0) {
-      return images.value; // No sections, return original order
+      return [...images.value].sort(byBatchOrder);
     }
     
     const result = [];
@@ -34,12 +28,9 @@ export function useSortedImages(images, floorplan) {
       }
     });
     
-    // Append unassigned images at the end
-    images.value.forEach(image => {
-      if (!assignedImageIds.has(image.imageId)) {
-        result.push(image);
-      }
-    });
+    // Append unassigned images at the end, sorted by batchUploadedAt desc → pickOrder asc
+    const unassigned = images.value.filter(image => !assignedImageIds.has(image.imageId));
+    result.push(...unassigned.sort(byBatchOrder));
     
     return result;
   });

--- a/src/services/locationService.js
+++ b/src/services/locationService.js
@@ -66,7 +66,7 @@ class LocationService {
   }
 
   // Add image metadata to a location
-  async addLocationImage(imageId, locationId, fileName, downloadUrl, routesetting, replacesImageId = null) {
+  async addLocationImage(imageId, locationId, fileName, downloadUrl, routesetting, replacesImageId = null, pickOrder, batchUploadedAt) {
     if (!routesetting) {
       throw new Error('routesetting is required. Create a routesetting for this location first.');
     }
@@ -78,6 +78,8 @@ class LocationService {
         fileName,
         downloadUrl,
         routesetting,
+        pickOrder,
+        batchUploadedAt,
       };
       if (replacesImageId) params.replacesImageId = replacesImageId;
       const result = await callFunction('addLocationImage', params);

--- a/src/services/locationService.js
+++ b/src/services/locationService.js
@@ -66,7 +66,7 @@ class LocationService {
   }
 
   // Add image metadata to a location
-  async addLocationImage(imageId, locationId, fileName, downloadUrl, routesetting, replacesImageId = null, pickOrder, batchUploadedAt) {
+  async addLocationImage({ imageId, locationId, fileName, downloadUrl, routesetting, replacesImageId = null, pickOrder, batchUploadedAt }) {
     if (!routesetting) {
       throw new Error('routesetting is required. Create a routesetting for this location first.');
     }

--- a/src/views/LocationDetailView.vue
+++ b/src/views/LocationDetailView.vue
@@ -1463,7 +1463,9 @@ const handleImageUploadComplete = async (uploadResult) => {
       uploadResult.fileName,
       uploadResult.downloadUrl,
       uploadResult.routesetting,
-      uploadResult.replacesImageId || null
+      uploadResult.replacesImageId || null,
+      uploadResult.pickOrder,
+      uploadResult.batchUploadedAt,
     );
 
     // Add the new image to the images array for immediate display
@@ -1473,6 +1475,8 @@ const handleImageUploadComplete = async (uploadResult) => {
       url: uploadResult.downloadUrl,
       name: uploadResult.fileName,
       uploadedAt: Date.now(), // Use current timestamp - we just uploaded it!
+      pickOrder: uploadResult.pickOrder,
+      batchUploadedAt: uploadResult.batchUploadedAt,
     });
   } catch (error) {
     console.error('Error saving image metadata:', error);

--- a/src/views/LocationDetailView.vue
+++ b/src/views/LocationDetailView.vue
@@ -236,20 +236,37 @@
                   class="px-3 py-1.5 rounded-md text-sm font-medium whitespace-nowrap bg-blue-600 text-white border-2 border-blue-300 outline-none w-32"
                 />
                 <!-- Normal tab -->
-                <button
-                  v-else
-                  @click="selectedFloorplanId = fp.id"
-                  @dblclick="userStore.canEditLocations && startRename(fp)"
-                  :title="userStore.canEditLocations ? 'Double-click to rename' : undefined"
-                  :class="[
-                    'px-3 py-1.5 rounded-md text-sm font-medium whitespace-nowrap transition-colors',
-                    (selectedFloorplanId === fp.id || (!selectedFloorplanId && fp === location.floorplans[0]))
-                      ? 'bg-blue-600 text-white'
-                      : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                  ]"
-                >
-                  {{ fp.name }}
-                </button>
+                <div v-else class="flex items-center">
+                  <button
+                    @click="selectedFloorplanId = fp.id"
+                    @dblclick="userStore.canEditLocations && startRename(fp)"
+                    :title="userStore.canEditLocations ? 'Double-click to rename' : undefined"
+                    :class="[
+                      'px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-colors',
+                      isFloorplanEditMode && userStore.canEditLocations ? 'rounded-l-md' : 'rounded-md',
+                      (selectedFloorplanId === fp.id || (!selectedFloorplanId && fp === location.floorplans[0]))
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                    ]"
+                  >
+                    {{ fp.name }}
+                  </button>
+                  <!-- Delete area button (edit mode only) -->
+                  <button
+                    v-if="isFloorplanEditMode && userStore.canEditLocations"
+                    @click="deleteFloorplan(fp)"
+                    :disabled="location.floorplans.length <= 1"
+                    :title="location.floorplans.length <= 1 ? 'Cannot delete the last area' : `Delete area &quot;${fp.name}&quot;`"
+                    :class="[
+                      'flex items-center justify-center w-6 h-full px-1 rounded-r-md text-xs font-bold transition-colors border-l',
+                      (selectedFloorplanId === fp.id || (!selectedFloorplanId && fp === location.floorplans[0]))
+                        ? 'bg-blue-700 border-blue-500 text-white hover:bg-red-600 disabled:opacity-40'
+                        : 'bg-gray-200 border-gray-300 text-gray-500 hover:bg-red-100 hover:text-red-600 disabled:opacity-40'
+                    ]"
+                  >
+                    ✕
+                  </button>
+                </div>
               </template>
             </template>
             <button
@@ -1021,6 +1038,22 @@ const addFloorplan = async () => {
   }
 };
 
+const deleteFloorplan = async (fp) => {
+  if (!location.value || location.value.floorplans.length <= 1) return;
+  if (!confirm(`Delete area "${fp.name}"? This cannot be undone.`)) return;
+  const updatedPlans = location.value.floorplans.filter(p => p.id !== fp.id);
+  try {
+    await locationService.updateLocation(locationId.value, { floorplans: updatedPlans });
+    location.value.floorplans = updatedPlans;
+    if (selectedFloorplanId.value === fp.id) {
+      selectedFloorplanId.value = updatedPlans[0].id;
+    }
+  } catch (err) {
+    console.error('Error deleting area:', err);
+    toast.error('Failed to delete area');
+  }
+};
+
 // Handle video deletion
 const handleVideoDeleted = async (videoId) => {
   // Find the video to get its problemId before removing it
@@ -1457,16 +1490,16 @@ const handleImageUploadComplete = async (uploadResult) => {
     // Save image metadata to Firestore via backend function
     // Use client-generated imageId (same as Storage folder name)
     // Pass routesetting timestamp for version control
-    await locationService.addLocationImage(
-      uploadResult.imageId,
-      uploadResult.locationId,
-      uploadResult.fileName,
-      uploadResult.downloadUrl,
-      uploadResult.routesetting,
-      uploadResult.replacesImageId || null,
-      uploadResult.pickOrder,
-      uploadResult.batchUploadedAt,
-    );
+    await locationService.addLocationImage({
+      imageId: uploadResult.imageId,
+      locationId: uploadResult.locationId,
+      fileName: uploadResult.fileName,
+      downloadUrl: uploadResult.downloadUrl,
+      routesetting: uploadResult.routesetting,
+      replacesImageId: uploadResult.replacesImageId,
+      pickOrder: uploadResult.pickOrder,
+      batchUploadedAt: uploadResult.batchUploadedAt,
+    });
 
     // Add the new image to the images array for immediate display
     // Use Date.now() since we know it was just uploaded (Cloud Function timestamps get serialized)


### PR DESCRIPTION
Introduce pickOrder and batchUploadedAt to preserve file-picker ordering for multi-file uploads. Adds a migration to backfill these fields for existing locationImages. Server: extend LocationImage types, require pickOrder and batchUploadedAt when adding images, and sort returned images by batchUploadedAt desc then pickOrder asc. Client: set batchUploadedAt for each upload batch and assign per-file pickOrder; include these fields in upload requests and when appending new images locally. Also update sorting composable and location service to respect the new ordering.