### PR TITLE
Split draft clusters into spatial subgroups

### DIFF
--- a/src/components/ImageUploadModal.vue
+++ b/src/components/ImageUploadModal.vue
@@ -42,7 +42,7 @@
                   : 'border-gray-200 hover:border-gray-400',
               ]"
             >
-              <img :src="img.url" :alt="img.name" class="w-full aspect-square object-cover" />
+              <img :src="img.url" :alt="img.name" class="w-full aspect-square object-cover" crossorigin="anonymous" />
             </button>
           </div>
           <p v-if="selectedReplacesImageId" class="text-[12px] text-amber-700 mt-1.5">

--- a/src/utils/problemSplitter.js
+++ b/src/utils/problemSplitter.js
@@ -148,8 +148,9 @@ function componentsFromEdges(holds, edges) {
     const group = [];
     const queue = [start];
     visited[start] = true;
-    while (queue.length > 0) {
-      const cur = queue.shift();
+    let qi = 0;
+    while (qi < queue.length) {
+      const cur = queue[qi++];
       group.push(holds[cur]);
       for (const nb of adj[cur]) {
         if (!visited[nb]) {

--- a/src/utils/problemSplitter.js
+++ b/src/utils/problemSplitter.js
@@ -1,0 +1,206 @@
+/**
+ * Spatial splitting of draft boulder problem clusters.
+ *
+ * A single color cluster returned by the server can contain holds from
+ * multiple distinct lines (e.g. two parallel routes of the same color).
+ * This module detects disconnected spatial groups within a flat hold array
+ * and returns them as separate sub-groups, each suitable for its own
+ * boulder problem.
+ *
+ * Algorithm — MST + Tukey fence outlier detection
+ * ------------------------------------------------
+ * 1. Build the Minimum Spanning Tree of holds (Kruskal's).
+ * 2. Compute the Tukey fence on MST edge lengths: Q3 + 1.5 × IQR.
+ * 3. Remove MST edges that exceed the fence — they are true gaps, not dynos.
+ * 4. Return connected components of the pruned MST.
+ *
+ * Why MST beats median×multiplier:
+ * - Self-calibrating: each cluster adapts to its own density.
+ * - Dynos are long edges but still within the distribution → fence stays above them.
+ * - Inter-problem gaps are statistical outliers → reliably above the fence.
+ * - When many dynos exist the fence shifts up automatically.
+ */
+
+// ---------------------------------------------------------------------------
+// Geometry helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the centre of a hold.
+ * Accepts both SimpleHold (centerX/centerY) and BaseHold (x+width/2).
+ *
+ * @param {object} hold
+ * @returns {{ x: number, y: number }}
+ */
+function getHoldCenter(hold) {
+  if (hold.centerX !== undefined && hold.centerY !== undefined) {
+    return { x: hold.centerX, y: hold.centerY };
+  }
+  return {
+    x: hold.x + (hold.width ?? 0) / 2,
+    y: hold.y + (hold.height ?? 0) / 2,
+  };
+}
+
+/**
+ * Euclidean distance between two centre points.
+ *
+ * @param {{ x: number, y: number }} a
+ * @param {{ x: number, y: number }} b
+ * @returns {number}
+ */
+function dist(a, b) {
+  return Math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2);
+}
+
+// ---------------------------------------------------------------------------
+// Kruskal's MST (union-find)
+// ---------------------------------------------------------------------------
+
+function makeUnionFind(n) {
+  const parent = Array.from({ length: n }, (_, i) => i);
+  const rank = new Array(n).fill(0);
+  function find(x) {
+    if (parent[x] !== x) parent[x] = find(parent[x]);
+    return parent[x];
+  }
+  function union(a, b) {
+    const ra = find(a), rb = find(b);
+    if (ra === rb) return false;
+    if (rank[ra] < rank[rb]) parent[ra] = rb;
+    else if (rank[ra] > rank[rb]) parent[rb] = ra;
+    else { parent[rb] = ra; rank[ra]++; }
+    return true;
+  }
+  return { find, union };
+}
+
+/**
+ * Builds the MST of `holds` and returns its edges sorted by length.
+ *
+ * @param {object[]} holds
+ * @returns {{ i: number, j: number, d: number }[]}
+ */
+function buildMST(holds) {
+  const centers = holds.map(getHoldCenter);
+
+  // Collect all pairwise edges
+  const edges = [];
+  for (let i = 0; i < holds.length; i++) {
+    for (let j = i + 1; j < holds.length; j++) {
+      edges.push({ i, j, d: dist(centers[i], centers[j]) });
+    }
+  }
+  edges.sort((a, b) => a.d - b.d);
+
+  const uf = makeUnionFind(holds.length);
+  const mst = [];
+  for (const edge of edges) {
+    if (uf.union(edge.i, edge.j)) {
+      mst.push(edge);
+      if (mst.length === holds.length - 1) break;
+    }
+  }
+  return mst;
+}
+
+// ---------------------------------------------------------------------------
+// Tukey fence outlier detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the Tukey outer fence cutoff for an array of values.
+ * Values above Q3 + fenceK × IQR are considered outliers.
+ *
+ * @param {number[]} values  - already sorted ascending
+ * @param {number}  [fenceK=1.5]
+ * @returns {number}
+ */
+function tukeyFence(values, fenceK = 1.5) {
+  const n = values.length;
+  const q1 = values[Math.floor(n * 0.25)];
+  const q3 = values[Math.floor(n * 0.75)];
+  return q3 + fenceK * (q3 - q1);
+}
+
+// ---------------------------------------------------------------------------
+// Connected components on a pruned edge set (BFS)
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {object[]} holds
+ * @param {{ i: number, j: number }[]} edges  - subset of edges to traverse
+ * @returns {object[][]}
+ */
+function componentsFromEdges(holds, edges) {
+  // Build adjacency list
+  const adj = Array.from({ length: holds.length }, () => []);
+  for (const { i, j } of edges) {
+    adj[i].push(j);
+    adj[j].push(i);
+  }
+
+  const visited = new Array(holds.length).fill(false);
+  const groups = [];
+
+  for (let start = 0; start < holds.length; start++) {
+    if (visited[start]) continue;
+    const group = [];
+    const queue = [start];
+    visited[start] = true;
+    while (queue.length > 0) {
+      const cur = queue.shift();
+      group.push(holds[cur]);
+      for (const nb of adj[cur]) {
+        if (!visited[nb]) {
+          visited[nb] = true;
+          queue.push(nb);
+        }
+      }
+    }
+    groups.push(group);
+  }
+
+  return groups;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Splits a flat array of holds into spatially-distinct groups using
+ * MST + Tukey fence outlier detection.
+ *
+ * @param {object[]} holds
+ * @param {object}   [opts]
+ * @param {number}   [opts.fenceK=1.5]  - Tukey multiplier (higher = less splitting)
+ * @returns {object[][]}
+ */
+export function splitHoldsByProximity(holds, { fenceK = 1.5 } = {}) {
+  if (holds.length < 2) return [holds];
+
+  const mst = buildMST(holds);
+  if (mst.length === 0) return [holds];
+
+  const lengths = mst.map(e => e.d).sort((a, b) => a - b);
+  const cutoff = tukeyFence(lengths, fenceK);
+  const keptEdges = mst.filter(e => e.d <= cutoff);
+
+  return componentsFromEdges(holds, keptEdges);
+}
+
+/**
+ * Analyses a draft cluster's holds and returns split metadata.
+ *
+ * @param {object[]} holds
+ * @param {object}   [opts]  - forwarded to splitHoldsByProximity
+ * @returns {{ needsSplit: boolean, groups: object[][] }}
+ */
+export function analyzeDraftCluster(holds, opts = {}) {
+  const groups = splitHoldsByProximity(holds, opts);
+  return {
+    needsSplit: groups.length > 1,
+    groups,
+  };
+}

--- a/src/views/HoldDetectionServerView.vue
+++ b/src/views/HoldDetectionServerView.vue
@@ -384,33 +384,57 @@
                           <div
                             v-for="cluster in sortedDraftClusters"
                             :key="cluster.clusterId"
-                            @click="toggleDraftCluster(cluster.clusterId)"
-                            class="flex items-center justify-between p-1.5 rounded-lg border cursor-pointer transition-colors text-xs"
+                            class="rounded-lg border text-xs"
                             :class="selectedDraftClusterId === cluster.clusterId
                               ? 'bg-indigo-50 border-indigo-300'
-                              : 'bg-gray-50 border-gray-100 hover:bg-gray-100'"
+                              : 'bg-gray-50 border-gray-100'"
                           >
-                            <div class="flex items-center space-x-1.5">
-                              <div
-                                class="w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-bold text-white"
-                                :style="{ backgroundColor: cluster.dominantColor || clusterColor(cluster.clusterId) }"
-                              >
-                                {{ cluster.clusterId }}
-                              </div>
-                              <span class="text-gray-700">{{ cluster.holdIds.length }}</span>
-                              <span v-if="cluster.colorName" class="font-medium text-gray-500 capitalize">
-                                {{ cluster.colorName }}
-                              </span>
-                              <span class="text-green-600" v-if="cluster.unusedCount > 0">
-                                {{ cluster.unusedCount }} new
-                              </span>
-                            </div>
-                            <button
-                              @click.stop="useDraftCluster(cluster)"
-                              class="font-medium text-indigo-600 hover:text-indigo-800 hover:underline"
+                            <!-- Parent row -->
+                            <div
+                              @click="toggleDraftCluster(cluster.clusterId)"
+                              class="flex items-center justify-between p-1.5 cursor-pointer transition-colors hover:bg-gray-100 rounded-lg"
                             >
-                              Use
-                            </button>
+                              <div class="flex items-center space-x-1.5">
+                                <div
+                                  class="w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-bold text-white"
+                                  :style="{ backgroundColor: cluster.dominantColor || clusterColor(cluster.clusterId) }"
+                                >
+                                  {{ cluster.clusterId }}
+                                </div>
+                                <span class="text-gray-700">{{ cluster.holdIds.length }}</span>
+                                <span v-if="cluster.colorName" class="font-medium text-gray-500 capitalize">
+                                  {{ cluster.colorName }}
+                                </span>
+                                <span class="text-green-600" v-if="cluster.unusedCount > 0">
+                                  {{ cluster.unusedCount }} new
+                                </span>
+                              </div>
+                              <button
+                                @click.stop="useDraftCluster(cluster)"
+                                class="font-medium text-indigo-600 hover:text-indigo-800 hover:underline"
+                              >
+                                Use
+                              </button>
+                            </div>
+                            <!-- Sub-groups (indented, only when split detected) -->
+                            <div v-if="cluster.subGroups.length > 1" class="pl-5 pb-1 space-y-0.5">
+                              <div
+                                v-for="sg in cluster.subGroups"
+                                :key="sg.label"
+                                class="flex items-center justify-between p-1 rounded border border-gray-200 bg-white"
+                              >
+                                <div class="flex items-center space-x-1.5">
+                                  <span class="font-mono text-gray-500">({{ sg.label }})</span>
+                                  <span class="text-gray-700">{{ sg.unusedCount }} holds</span>
+                                </div>
+                                <button
+                                  @click.stop="useDraftCluster(cluster, sg.holdIds)"
+                                  class="font-medium text-indigo-600 hover:text-indigo-800 hover:underline"
+                                >
+                                  Use
+                                </button>
+                              </div>
+                            </div>
                           </div>
                         </div>
                       </div>
@@ -880,38 +904,62 @@
                     <div
                       v-for="cluster in sortedDraftClusters"
                       :key="cluster.clusterId"
-                      @click="toggleDraftCluster(cluster.clusterId)"
-                      class="flex items-center justify-between p-2 rounded-lg border cursor-pointer transition-colors"
+                      class="rounded-lg border"
                       :class="selectedDraftClusterId === cluster.clusterId
                         ? 'bg-indigo-50 border-indigo-300'
-                        : 'bg-gray-50 border-gray-100 hover:bg-gray-100'"
+                        : 'bg-gray-50 border-gray-100'"
                     >
-                      <div class="flex items-center space-x-2">
-                        <div
-                          class="w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold text-white"
-                          :style="{ backgroundColor: cluster.dominantColor || clusterColor(cluster.clusterId) }"
-                        >
-                          {{ cluster.clusterId }}
-                        </div>
-                        <span class="text-sm text-gray-700">
-                          {{ cluster.holdIds.length }} holds
-                        </span>
-                        <span v-if="cluster.colorName" class="text-xs font-medium text-gray-500 capitalize">
-                          {{ cluster.colorName }}
-                        </span>
-                        <span class="text-xs text-green-600" v-if="cluster.unusedCount > 0">
-                          {{ cluster.unusedCount }} new
-                        </span>
-                        <span class="text-xs text-gray-400" v-if="cluster.usedCount > 0">
-                          {{ cluster.usedCount }} used
-                        </span>
-                      </div>
-                      <button
-                        @click.stop="useDraftCluster(cluster)"
-                        class="text-xs font-medium text-indigo-600 hover:text-indigo-800 hover:underline"
+                      <!-- Parent row -->
+                      <div
+                        @click="toggleDraftCluster(cluster.clusterId)"
+                        class="flex items-center justify-between p-2 cursor-pointer transition-colors hover:bg-gray-100 rounded-lg"
                       >
-                        Use
-                      </button>
+                        <div class="flex items-center space-x-2">
+                          <div
+                            class="w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold text-white"
+                            :style="{ backgroundColor: cluster.dominantColor || clusterColor(cluster.clusterId) }"
+                          >
+                            {{ cluster.clusterId }}
+                          </div>
+                          <span class="text-sm text-gray-700">
+                            {{ cluster.holdIds.length }} holds
+                          </span>
+                          <span v-if="cluster.colorName" class="text-xs font-medium text-gray-500 capitalize">
+                            {{ cluster.colorName }}
+                          </span>
+                          <span class="text-xs text-green-600" v-if="cluster.unusedCount > 0">
+                            {{ cluster.unusedCount }} new
+                          </span>
+                          <span class="text-xs text-gray-400" v-if="cluster.usedCount > 0">
+                            {{ cluster.usedCount }} used
+                          </span>
+                        </div>
+                        <button
+                          @click.stop="useDraftCluster(cluster)"
+                          class="text-xs font-medium text-indigo-600 hover:text-indigo-800 hover:underline"
+                        >
+                          Use
+                        </button>
+                      </div>
+                      <!-- Sub-groups (indented, only when split detected) -->
+                      <div v-if="cluster.subGroups.length > 1" class="pl-6 pb-2 space-y-1">
+                        <div
+                          v-for="sg in cluster.subGroups"
+                          :key="sg.label"
+                          class="flex items-center justify-between p-1.5 rounded border border-gray-200 bg-white"
+                        >
+                          <div class="flex items-center space-x-2">
+                            <span class="text-xs font-mono text-gray-500">({{ sg.label }})</span>
+                            <span class="text-sm text-gray-700">{{ sg.unusedCount }} holds</span>
+                          </div>
+                          <button
+                            @click.stop="useDraftCluster(cluster, sg.holdIds)"
+                            class="text-xs font-medium text-indigo-600 hover:text-indigo-800 hover:underline"
+                          >
+                            Use
+                          </button>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1193,6 +1241,7 @@ import HoldMatchVisualizer from '@/components/HoldMatchVisualizer.vue';
 import { ensureHoldHasSvgMarkup } from '@/utils/svgUtils.js';
 import { hexToColorName, precomputeHoldHues } from '@/utils/colorUtils.js';
 import { performMagicWandSelection } from '@/utils/magicWandUtils.js';
+import { analyzeDraftCluster } from '@/utils/problemSplitter.js';
 import { getHoldDetectionServerUrl, getClusterServerUrl } from '@/services/appConfigService';
 import { mapMatchesToHolds, computeHoldToHoldMapping, computeMatchToDetectionScale } from '@/utils/holdMatcher';
 // Note: Not using getResizedImageUrl - we load original images to match detection coordinates
@@ -1392,6 +1441,7 @@ const allHoldIds = computed(() => {
 const usedHoldIds = computed(() => {
   const ids = new Set();
   for (const problem of boulderProblemsStore.sortedProblems) {
+    if (problem.isLocalOnly) continue; // exclude in-progress, only count persisted
     for (const h of problem.holds || []) {
       ids.add(h.holdId);
     }
@@ -1432,11 +1482,25 @@ const toggleShowUnassigned = () => {
 // Clusters enriched with used/unused counts + color name from API hex, sorted by most unused
 const sortedDraftClusters = computed(() => {
   if (!draftState.value.clusters) return [];
+  const aiHolds = serverStore.results?.holds || [];
   return draftState.value.clusters
     .map(cluster => {
       const used = cluster.holdIds.filter(id => usedHoldIds.value.has(id)).length;
       const colorName = hexToColorName(cluster.dominantColor);
-      return { ...cluster, usedCount: used, unusedCount: cluster.holdIds.length - used, colorName };
+
+      // Compute spatial sub-groups on the unused holds of this cluster
+      const unusedIds = cluster.holdIds.filter(id => !usedHoldIds.value.has(id));
+      const resolvedHolds = unusedIds.map(id => aiHolds.find(h => h.id === id)).filter(Boolean);
+      const { needsSplit, groups } = analyzeDraftCluster(resolvedHolds);
+      const subGroups = needsSplit
+        ? groups.map((g, i) => ({
+            holdIds: g.map(h => h.id),
+            label: `${cluster.clusterId}${"'".repeat(i + 1)}`,
+            unusedCount: g.length,
+          }))
+        : [];
+
+      return { ...cluster, usedCount: used, unusedCount: cluster.holdIds.length - used, colorName, subGroups };
     })
     .sort((a, b) => b.unusedCount - a.unusedCount);
 });
@@ -1446,27 +1510,44 @@ const toggleDraftCluster = (clusterId) => {
   if (selectedDraftClusterId.value !== null) showUnassigned.value = false;
 };
 
-const useDraftCluster = async (cluster) => {
-  // Cancel any in-progress creation first
+/**
+ * @param {object} cluster - entry from sortedDraftClusters
+ * @param {string[]|null} overrideHoldIds - when set, create exactly one problem with these holds
+ */
+const useDraftCluster = async (cluster, overrideHoldIds = null) => {
   if (boulderProblemsStore.isCreatingProblem) {
     boulderProblemsStore.cancelCreatingProblem();
   }
   showUnassigned.value = false;
 
   const color = cluster.dominantColor || clusterColor(cluster.clusterId);
-  const name = cluster.colorName
-    ? `${cluster.colorName.charAt(0).toUpperCase() + cluster.colorName.slice(1)}`
+  const baseName = cluster.colorName
+    ? cluster.colorName.charAt(0).toUpperCase() + cluster.colorName.slice(1)
     : `Draft ${cluster.clusterId}`;
-  sharedProblemName.value = name;
   const defaultGrade = boulderProblemsStore.grades[0] || null;
-  sharedSelectedGrade.value = defaultGrade || '';
-  boulderProblemsStore.createNewProblem(defaultGrade, name, color);
 
-  const problem = boulderProblemsStore.activeProblem;
-  if (!problem) return;
+  if (overrideHoldIds) {
+    // Single sub-group "Use" — create exactly one problem
+    sharedProblemName.value = baseName;
+    sharedSelectedGrade.value = defaultGrade || '';
+    boulderProblemsStore.createNewProblem(defaultGrade, baseName, color);
+    const problem = boulderProblemsStore.activeProblem;
+    if (problem) addHoldsByIds(overrideHoldIds, problem);
+  } else {
+    // Parent "Use" — create one problem per pre-computed sub-group (or one if no split)
+    const groups = cluster.subGroups?.length > 0
+      ? cluster.subGroups.map(sg => sg.holdIds)
+      : [cluster.holdIds.filter(id => !usedHoldIds.value.has(id))];
 
-  const newHoldIds = cluster.holdIds.filter(id => !usedHoldIds.value.has(id));
-  addHoldsByIds(newHoldIds, problem);
+    for (let i = 0; i < groups.length; i++) {
+      const name = groups.length > 1 ? `${baseName} ${i + 1}` : baseName;
+      sharedProblemName.value = name;
+      sharedSelectedGrade.value = defaultGrade || '';
+      boulderProblemsStore.createNewProblem(defaultGrade, name, color);
+      const problem = boulderProblemsStore.activeProblem;
+      if (problem) addHoldsByIds(groups[i], problem);
+    }
+  }
 
   selectedDraftClusterId.value = null;
 };

--- a/src/views/HoldDetectionServerView.vue
+++ b/src/views/HoldDetectionServerView.vue
@@ -1483,6 +1483,7 @@ const toggleShowUnassigned = () => {
 const sortedDraftClusters = computed(() => {
   if (!draftState.value.clusters) return [];
   const aiHolds = serverStore.results?.holds || [];
+  const holdById = new Map(aiHolds.map(h => [h.id, h]));
   return draftState.value.clusters
     .map(cluster => {
       const used = cluster.holdIds.filter(id => usedHoldIds.value.has(id)).length;
@@ -1490,7 +1491,7 @@ const sortedDraftClusters = computed(() => {
 
       // Compute spatial sub-groups on the unused holds of this cluster
       const unusedIds = cluster.holdIds.filter(id => !usedHoldIds.value.has(id));
-      const resolvedHolds = unusedIds.map(id => aiHolds.find(h => h.id === id)).filter(Boolean);
+      const resolvedHolds = unusedIds.map(id => holdById.get(id)).filter(Boolean);
       const { needsSplit, groups } = analyzeDraftCluster(resolvedHolds);
       const subGroups = needsSplit
         ? groups.map((g, i) => ({
@@ -1512,7 +1513,7 @@ const toggleDraftCluster = (clusterId) => {
 
 /**
  * @param {object} cluster - entry from sortedDraftClusters
- * @param {string[]|null} overrideHoldIds - when set, create exactly one problem with these holds
+ * @param {string[]|null} overrideHoldIds - when set, create exactly one problem with these hold IDs
  */
 const useDraftCluster = async (cluster, overrideHoldIds = null) => {
   if (boulderProblemsStore.isCreatingProblem) {
@@ -1526,28 +1527,24 @@ const useDraftCluster = async (cluster, overrideHoldIds = null) => {
     : `Draft ${cluster.clusterId}`;
   const defaultGrade = boulderProblemsStore.grades[0] || null;
 
-  if (overrideHoldIds) {
-    // Single sub-group "Use" — create exactly one problem
-    sharedProblemName.value = baseName;
-    sharedSelectedGrade.value = defaultGrade || '';
-    boulderProblemsStore.createNewProblem(defaultGrade, baseName, color);
-    const problem = boulderProblemsStore.activeProblem;
-    if (problem) addHoldsByIds(overrideHoldIds, problem);
-  } else {
-    // Parent "Use" — create one problem per pre-computed sub-group (or one if no split)
-    const groups = cluster.subGroups?.length > 0
-      ? cluster.subGroups.map(sg => sg.holdIds)
-      : [cluster.holdIds.filter(id => !usedHoldIds.value.has(id))];
+  // Determine which hold IDs to load into the new problem.
+  // When split sub-groups exist and no override is given, load the first sub-group
+  // so the user edits one problem at a time. The other sub-groups remain as draft
+  // rows and can be used individually.
+  const holdIds = overrideHoldIds
+    ?? (cluster.subGroups?.length > 1
+      ? cluster.subGroups[0].holdIds
+      : cluster.holdIds.filter(id => !usedHoldIds.value.has(id)));
 
-    for (let i = 0; i < groups.length; i++) {
-      const name = groups.length > 1 ? `${baseName} ${i + 1}` : baseName;
-      sharedProblemName.value = name;
-      sharedSelectedGrade.value = defaultGrade || '';
-      boulderProblemsStore.createNewProblem(defaultGrade, name, color);
-      const problem = boulderProblemsStore.activeProblem;
-      if (problem) addHoldsByIds(groups[i], problem);
-    }
-  }
+  const name = (!overrideHoldIds && cluster.subGroups?.length > 1)
+    ? `${baseName} 1`
+    : baseName;
+
+  sharedProblemName.value = name;
+  sharedSelectedGrade.value = defaultGrade || '';
+  boulderProblemsStore.createNewProblem(defaultGrade, name, color);
+  const problem = boulderProblemsStore.activeProblem;
+  if (problem) addHoldsByIds(holdIds, problem);
 
   selectedDraftClusterId.value = null;
 };

--- a/src/views/HoldDetectionServerView.vue
+++ b/src/views/HoldDetectionServerView.vue
@@ -84,12 +84,12 @@
                 >
                   <div class="relative flex-1 min-w-0 flex items-center justify-center">
                     <span class="absolute top-2 left-2 z-10 text-[11px] font-semibold bg-black/60 text-white px-2 py-0.5 rounded-full">Previous</span>
-                    <img :src="replacedImageUrl" alt="Previous wall" class="w-full h-full object-contain block" style="max-height: 70vh" />
+                    <img :src="replacedImageUrl" alt="Previous wall" class="w-full h-full object-contain block" style="max-height: 70vh" crossorigin="anonymous" />
                   </div>
                   <div class="w-[3px] bg-amber-400 flex-shrink-0" />
                   <div class="relative flex-1 min-w-0 flex items-center justify-center">
                     <span class="absolute top-2 left-2 z-10 text-[11px] font-semibold bg-black/60 text-white px-2 py-0.5 rounded-full">Current</span>
-                    <img :src="(currentImage as any).url" alt="Current wall" class="w-full h-full object-contain block" style="max-height: 70vh" />
+                    <img :src="(currentImage as any).url" alt="Current wall" class="w-full h-full object-contain block" style="max-height: 70vh" crossorigin="anonymous" />
                   </div>
                 </div>
 


### PR DESCRIPTION
Add a spatial splitter util and integrate subgroup handling in the hold-detection UI.

- New src/utils/problemSplitter.js: MST (Kruskal) + Tukey fence based algorithm to detect spatially disconnected groups within a cluster; exports splitHoldsByProximity and analyzeDraftCluster.
- HoldDetectionServerView.vue:
  - Import and use analyzeDraftCluster to compute subGroups for the unused holds of each draft cluster.
  - Render indented subgroup rows in the cluster list with their own "Use" action.
  - Update useDraftCluster to support creating one problem per subgroup or creating a single problem for a chosen subgroup (overrideHoldIds).
  - Minor UI restructuring/styling for parent row vs subgroup rows and improved labels/counts.
  - Exclude local-only problems when computing usedHoldIds so in-progress problems aren't counted.

This enables automatic detection of multiple routes in a single color cluster and lets the user create problems per detected subgroup.